### PR TITLE
Updated ArducamSpi.cpp, Changed "return SPI.begin();" to "SPI.begin();"

### DIFF
--- a/src/Arducam/ArducamSpi.cpp
+++ b/src/Arducam/ArducamSpi.cpp
@@ -15,7 +15,7 @@
 
 void arducamSpiBegin(void)
 {
-    return SPI.begin();
+    SPI.begin();
 }
 
 uint8_t arducamSpiTransfer(uint8_t data)


### PR DESCRIPTION
###ERROR
In function 'void arducamSpiBegin()':
error: return-statement with a value, in function returning 'void' [-fpermissive]

###FIX
void arducamSpiBegin(void)
{
    SPI.begin();
}